### PR TITLE
REST-Gateway, Add check for matching credential configuration format

### DIFF
--- a/internal/gateway/rest/rest_gateway.go
+++ b/internal/gateway/rest/rest_gateway.go
@@ -129,6 +129,7 @@ func (g RestGateway) RequestCredential(c *gin.Context) {
 				if c.Format == req.Format {
 					credentialConfig = c
 					req.CredentialConfigurationId = i
+					ok = true
 					break
 				}
 			}


### PR DESCRIPTION
Fixed a bug in RequestCredential where valid credential requests were being rejected with ErrUnsupportedCredentialFormat.

Problem: The `ok` boolean flag used to track if a matching CredentialConfiguration was found remained false regardless of the loop outcome.

Fix: Added `ok = true` inside the format matching block.

Impact: This ensures that when a requested format matches the issuer's supported configurations, the validation logic proceeds to the proof check rather than incorrectly returning a 400 Bad Request.